### PR TITLE
Update README instructions to use version 1.0.1 (stable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Upgrade instructions from each version are included below.
 Add `critical-path-css-rails` to your Gemfile:
 
 ```
-gem 'critical-path-css-rails', '~> 1.0.0'
+gem 'critical-path-css-rails', '~> 1.0.1'
 ```
 
 Download and install by running:


### PR DESCRIPTION
Just update the README version of the instructions to the working one 1.0.1