### PR TITLE
Allow Regexp in confing yml file

### DIFF
--- a/lib/critical_path_css/rails/config_loader.rb
+++ b/lib/critical_path_css/rails/config_loader.rb
@@ -4,7 +4,7 @@ module CriticalPathCss
       CONFIGURATION_FILENAME = 'critical_path_css.yml'.freeze
 
       def load
-        config = YAML.safe_load(ERB.new(File.read(configuration_file_path)).result, [], [], true)[::Rails.env]
+        config = YAML.safe_load(ERB.new(File.read(configuration_file_path)).result, [::Regexp], [], true)[::Rails.env]
         config['css_path'] = "#{::Rails.root}/public" + (
             config['css_path'] ||
               ActionController::Base.helpers.stylesheet_path(

--- a/lib/critical_path_css/rails/version.rb
+++ b/lib/critical_path_css/rails/version.rb
@@ -1,5 +1,5 @@
 module CriticalPathCSS
   module Rails
-    VERSION = '2.4.0'.freeze
+    VERSION = '2.4.1'.freeze
   end
 end


### PR DESCRIPTION
This changes allow for the developers to use regexp in config file. 
Regexp is needed for penthouse options for example for `forceInclude` option. 

For option like penthouse documentations `forceInclude: ['.keepMeEvenIfNotSeenInDom', /^\.button/])` it will be looks like : 

``` yml
penthouse_options:
  forceInclude:
    - '.keepMeEvenIfNotSeenInDom'
    - !ruby/regexp '/^\.button/'
