### PR TITLE
Update Example Based on loadCSS Best Practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A simple example using [loadcss-rails](https://github.com/michael-misshore/loadc
 <script>
     loadCSS("<%= stylesheet_path('application') %>");
 </script>
-<link rel="preload" href="<%= stylesheet_path('application') %>" as="style" onload="this.rel='stylesheet'">
+<link rel="preload" href="<%= stylesheet_path('application') %>" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript>
     <link rel="stylesheet" href="<%= stylesheet_path('application') %>">
 </noscript>


### PR DESCRIPTION
`this.onload=null` is a necessary addition to the `<link>` tag in order to prevent failures in IE11 and Edge, per filamentgroup/loadCSS#262