### PR TITLE
Return first css path when route index is nil

### DIFF
--- a/lib/critical_path_css/configuration.rb
+++ b/lib/critical_path_css/configuration.rb
@@ -26,7 +26,7 @@ module CriticalPathCss
     end
 
     def path_for_route(route)
-      css_paths[routes.index(route)] || css_paths.first
+      css_paths[routes.index(route).to_i]
     end
   end
 end


### PR DESCRIPTION
I was using `CriticalPathCss.generate` to generate dynamic routes that aren't defined in `critical_path_css.yml`, and hit with this error `TypeError: no implicit conversion from nil to integer`.

The reason is because `routes.index(route)` is `nil`, and you cannot call `[nil]` in an array, hence `css_paths.first` is never called. Let me know if `.to_i` works, since it might seems too magical for some people. On the other hand, please let me know if I'm using the `.generate` method incorrectly...