### PR TITLE
update deprecated safe_load call (deprecated in psych 3, changed in psych 4+)

### DIFF
--- a/lib/critical_path_css/rails/config_loader.rb
+++ b/lib/critical_path_css/rails/config_loader.rb
@@ -9,7 +9,7 @@ module CriticalPathCss
       end
 
       def config
-        @config ||= YAML.safe_load(ERB.new(File.read(configuration_file_path)).result, [], [], true)[::Rails.env]
+        @config ||= YAML.safe_load(ERB.new(File.read(configuration_file_path)).result, aliases: true)[::Rails.env]
       end
 
       private


### PR DESCRIPTION
The arguments for the YAML.safe_load call have changed in Psych 3 to named parameters. From Psych 4 on, the old unnamed parameters have been removed. This PR uses the named parameters, making the gem compatible to Psych 4+ (currently: 5).